### PR TITLE
More Complex Message Handling

### DIFF
--- a/handlers/commands/embed.js
+++ b/handlers/commands/embed.js
@@ -1,6 +1,6 @@
 const config = require('../../index.js').config;
 const whitelist = require('../../index.js').wlConfig;
-const messages = require('../../messages.json');
+const msg = require('../../messageHandler.js');
 const parser = require('yargs-parser');
 const { Message } = require('discord.js');
 
@@ -9,7 +9,7 @@ const announcement = (message = new Message(), args_) => {
         return message.reply({
             embed: {
                 title: 'No Permissions',
-                description: messages.errors.no_permissions,
+                description: msg.get('errors.no_permissions'),
                 color: 'RED',
             },
         });
@@ -45,7 +45,7 @@ module.exports = {
             return message.reply({
                 embed: {
                     title: 'No Permissions',
-                    description: messages.errors.no_permissions,
+                    description: msg.get('errors.no_permissions'),
                     color: 'RED',
                 },
             });

--- a/handlers/commands/help.js
+++ b/handlers/commands/help.js
@@ -61,7 +61,7 @@ module.exports = {
                 const errorEmbed = {
                     title: 'Invalid Command',
                     color: 'RED',
-                    description: msgs.commands.help.invalid_command.replace('{command}', `\`${config.data.prefix}help\``),
+                    description: msg.get('errors.invalid_command', { command : `\`${config.data.prefix}help\``}),
                     timestamp: new Date(),
                     footer: {
                         text: `Requested by ${message.member.displayName}`,

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const Discord = require('discord.js');
 const logger = require('./logger.js');
 const config = require('./utils.js').Config;
 const wlConfig = require('./utils.js').WLConfig;
-const msgs = require('./messages.json');
+const msg = require('./messageHandler');
 module.exports.logger = logger;
 module.exports.config = config;
 module.exports.wlConfig = wlConfig;
@@ -41,7 +41,7 @@ client.on('message', (message) => {
         message.reply({
             embed: {
                 title: 'Invalid Command',
-                description: msgs.errors.invalid_command.replace('{command}', `\`${config.data.prefix}help\``),
+                description: msg.get('errors.invalid_command', { command : `\`${config.data.prefix}help\``}),
                 footer: { text: `Requested by ${message.member.displayName || message.member.user.username}` },
                 color: 'YELLOW',
             },

--- a/messageHandler.js
+++ b/messageHandler.js
@@ -2,7 +2,7 @@ let messages = require('./messages.json');
 
 /**
  * @param {(string|string[])} key - the location of the string in messages.json 
- * @param {Object} vars - Strings to replace the {variables} in the messages.json string
+ * @param {Object} [vars] - Strings to replace the {variables} in the messages.json string
  * @returns {String} - The combined message
  * Used to create messages from pre-defined strings in messages.json and variables passed in 
  */

--- a/messageHandler.js
+++ b/messageHandler.js
@@ -1,5 +1,11 @@
 let messages = require('./messages.json');
 
+/**
+ * @param {(string|string[])} key - the location of the string in messages.json 
+ * @param {Object} vars - Strings to replace the {variables} in the messages.json string
+ * @returns {String} - The combined message
+ * Used to create messages from pre-defined strings in messages.json and variables passed in 
+ */
 function getMessage(key, vars) {
     if (typeof key == "string") {
         key = key.split('.');
@@ -27,6 +33,13 @@ function getMessage(key, vars) {
     return message;
 }
 
+/**
+ * 
+ * @param {string} id - The log identifier, generally the name of the module or command
+ * @param {string} message - The message to be added
+ * @returns {string} - The resulting combined string
+ * Just a helper function to keep things a bit DRYer
+ */
 function logMessage(id, message) {
     return getMessage('log', { id: id, msg: message})
 }

--- a/messageHandler.js
+++ b/messageHandler.js
@@ -1,0 +1,39 @@
+let messages = require('./messages.json');
+
+function getMessage(key, vars) {
+    if (typeof key == "string") {
+        key = key.split('.');
+    }
+
+    let message = key.reduce((acc, value) => {
+        if (typeof acc[value] == "undefined") {
+            return {};
+        }
+        acc = acc[value];
+        return acc;
+    }, messages)
+
+    if (typeof message == "object") {
+        message = key.reduce((acc, value) => `${acc}.${value}`);
+    }
+
+    if (typeof vars != "undefined") {
+        Object.keys(vars).forEach((key) => {
+            let keyRegex = new RegExp(`{${key}}`, "g")
+            message = message.replace(keyRegex, vars[key]);
+        })
+    }
+    
+    return message;
+}
+
+function logMessage(id, message) {
+    return getMessage('log', { id: id, msg: message})
+}
+
+module.exports = {
+    get: getMessage,
+    getMessage,
+    log: logMessage,
+    logMessage
+}

--- a/messages.json
+++ b/messages.json
@@ -1,4 +1,5 @@
 {
+    "log" : "[{id}] {msg}",
     "commands": {
         "help": {
             "invalid_command": "No such command. Run {command} to view all available commands."


### PR DESCRIPTION
**What**
This pull request adds a "simple" message handler that can do look ups within the `messages.json` file as well as do simple string substitution. It also includes basic JSDOC tags in the messageHandler

**Why**
In an effect to make the codebase DRYer, this will allow string lookup and substitutions without repeating code, such as had happened in ` handlers/commands/help.js` and `index.js`. 

**How**
In any file you wish to use a string from `messages.json`, simply
```js
const msg = require('./messages'); // Or whichever path is required
```
then, using `msg.get(key, vars);` you can lookup and add substitutions to the string.   
The `key` parameter be either a string delimited by `.` (e.g. 'commands.help.invalid_command') or an array (e.g. ['commands', 'help', invalid_command'])
the (optional) `vars` parameter must be an object with the keys matching the string's variables (in this case `{command}`) with the value being the string to substitute with.

So for example:
```js
msg.get('commands.help.invalid_command', { command: 'ct!help' });
```
would return
> "No such command. Run ct!help to view all available commands"

There is also included a `msg.log(id, message)` function which just reduces a layer of complexity when wanting to create a string for the logger.